### PR TITLE
Fix compile and install to work with hatari

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ if (APPLE AND BUILD_FRAMEWORK)
     FRAMEWORK_VERSION C
     MACOSX_FRAMEWORK_IDENTIFIER com.kryoflux)
   set_source_files_properties(${API_HEADERS} PROPERTIES
-    MACOSX_PACKAGE_LOCATION Headers/caps)
+    MACOSX_PACKAGE_LOCATION Headers/caps5)
   set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9")
 endif ()
 
@@ -49,8 +49,8 @@ install(TARGETS capsimage
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
   FRAMEWORK DESTINATION "/Library/Frameworks"
-  PUBLIC_HEADER DESTINATION include/caps)
+  PUBLIC_HEADER DESTINATION include/caps5)
 
 if (NOT APPLE OR NOT BUILD_FRAMEWORK)
-  install(FILES ${API_HEADERS} DESTINATION include/caps)
+  install(FILES ${API_HEADERS} DESTINATION include/caps5)
 endif ()

--- a/src/CAPSImg/stdafx.h
+++ b/src/CAPSImg/stdafx.h
@@ -46,7 +46,7 @@
 #include <unistd.h>
 #define MAX_PATH ( 260 )
 #ifndef __cdecl
-#define __cdecl
+#define __cdecl __attribute__((cdecl))
 #endif
 
 #define _lrotl(x,n) (((x) << (n)) | ((x) >> (sizeof(x)*8-(n))))

--- a/src/Core/CommonTypes.h
+++ b/src/Core/CommonTypes.h
@@ -7,6 +7,18 @@ typedef int16_t WORD;
 typedef int32_t DWORD;
 #endif
 
+#ifdef AMIGA
+#include <exec/types.h>
+typedef UBYTE CapsUByte;
+typedef LONG  CapsLong;
+typedef ULONG CapsULong;
+#else
+#include <stdint.h>
+typedef uint8_t  CapsUByte;
+typedef int32_t  CapsLong;
+typedef uint32_t CapsULong;
+#endif // AMIGA
+
 typedef void *PVOID;
 typedef char *PCHAR;
 

--- a/src/LibIPF/CapsFDC.h
+++ b/src/LibIPF/CapsFDC.h
@@ -1,7 +1,7 @@
 #ifndef CAPSFDC_H
 #define CAPSFDC_H
 
-#include <ComLib.h>
+#include "ComLib.h"
 
 // drive defaults
 #define CAPSDRIVE_35DD_RPM 300

--- a/src/LibIPF/CapsFDC.h
+++ b/src/LibIPF/CapsFDC.h
@@ -1,6 +1,8 @@
 #ifndef CAPSFDC_H
 #define CAPSFDC_H
 
+#include <ComLib.h>
+
 // drive defaults
 #define CAPSDRIVE_35DD_RPM 300
 #define CAPSDRIVE_35DD_HST 83

--- a/src/LibIPF/ComLib.h
+++ b/src/LibIPF/ComLib.h
@@ -21,4 +21,7 @@
 #ifndef _WIN32
 #undef ExtSub
 #define ExtSub
+#ifndef __cdecl
+#define __cdecl __attribute__((cdecl))
+#endif
 #endif


### PR DESCRIPTION
- change __cdecl to support gcc __attribute__
- support integer type defines of earlier versions
- support installation of other versions with different include
directories