### PR TITLE
Apple Silicon (arm64) support in macOS builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,8 @@ set(MINOR_VERSION 1)
 option(BUILD_SHARED_LIBS "Build a dynamic library instead of static library" ON)
 
 if (APPLE)
-  option(BUILD_FRAMEWORK "Build a Mac OS X framework instead of a shared library" OFF)
-  set(CMAKE_OSX_ARCHITECTURES "i386;x86_64")
+  option(BUILD_FRAMEWORK "Build a macOS framework instead of a shared library" ON)
+  set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64")
   set(BUILD_SHARED_LIBS ON)
 endif()
 


### PR DESCRIPTION
- Build Universal 2 binaries (x86_64 + arm64) by default instead of i386 + x86_64.
- Build a macOS framework by default, as this is the most common way to consume the library on the platform.