### PR TITLE
Bugfix: if not Win32 then BYTE, WORD, DWORD are now correctly set

### DIFF
--- a/src/Core/CommonTypes.h
+++ b/src/Core/CommonTypes.h
@@ -2,9 +2,10 @@
 #define COMMONTYPES_H
 
 #ifndef _WIN32
-typedef int8_t BYTE;
-typedef int16_t WORD;
-typedef int32_t DWORD;
+#include <cstdint>
+typedef uint8_t BYTE;
+typedef uint16_t WORD;
+typedef uint32_t DWORD;
 #endif
 
 #ifdef AMIGA


### PR DESCRIPTION
Bugfix: if not Win32 then BYTE, WORD, DWORD are now correctly set as unsigned in CommonTypes.h.

The proper include is also added (cstdint).
Probably these 3 types are not used at all, removing this #ifndef _WIN32 block should also work.

The problem was that these 3 types are defined as unsigned in Linux (and in Windows anyway) and these signed redefined types conflicted with those.